### PR TITLE
Support restoring from PIP from watching from the downloads tab

### DIFF
--- a/Fetch/DownloadsTableViewController.swift
+++ b/Fetch/DownloadsTableViewController.swift
@@ -169,7 +169,8 @@ class DownloadsTableViewController: UITableViewController, DownloaderDelegate {
     
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if let vc = segue.destinationViewController as? AVPlayerViewController, let file = sender as? String {
-            
+            vc.delegate = PlayerDelegate.sharedInstance
+
             let documentsUrl =  NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).first!
             let fileUrl = documentsUrl.URLByAppendingPathComponent(file)
             


### PR DESCRIPTION
Just needed to set the delegate so that `func playerViewController(playerViewController: AVPlayerViewController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: (Bool) -> Void)` is handled.