### PR TITLE
Update oauth2 redirect URI

### DIFF
--- a/Fetch/LoginViewController.swift
+++ b/Fetch/LoginViewController.swift
@@ -61,9 +61,9 @@ class LoginViewController: UIViewController, UIWebViewDelegate {
         let url = webView.request?.mainDocumentURL
         let urlString = url!.absoluteString
         
-        if(urlString!.rangeOfString("http://getfetchapp.com/authenticate/success.php") != nil) {
+        if(urlString!.rangeOfString("http://getfetchapp.com/authenticate") != nil) {
             
-            let accessToken = url?.query!.stringByReplacingOccurrencesOfString("access_token=", withString: "", options: [], range: nil)
+            let accessToken = url?.fragment!.stringByReplacingOccurrencesOfString("access_token=", withString: "", options: [], range: nil)
             
             Putio.keychain.updateIfNeeded("access_token", value: accessToken)
             


### PR DESCRIPTION
After fresh install, I was unable to login and it seems some changes either on put.io API or elsewhere. The following changes allowed me to progress, perhaps there is a better solution. I'm not too familiar with the oauth flow and used this as quickest route to be able to login.