### PR TITLE
Fix unable to add urls

### DIFF
--- a/Fetch/AddFilesViewController.swift
+++ b/Fetch/AddFilesViewController.swift
@@ -170,8 +170,8 @@ class AddFilesViewController: UIViewController, UITextViewDelegate {
             
         } else {
             
-            let url = textView.text
-            var params: [String:Any] = ["oauth_token": "\(Putio.accessToken!)", "url": url as Any, "extract": "true"]
+            let url = textView.text!
+            var params = ["oauth_token": "\(Putio.accessToken!)", "url": url, "extract": "true"]
             
             // load the save_parent_id from the visible view controller
             let vc = folderPickerController!.visibleViewController as! FolderSelectTableViewController


### PR DESCRIPTION
This was caused by the swift3 conversion.
This is a subtle change in swift3, see https://stackoverflow.com/a/39537558/158525
Explicitly unwrapping the url fixes the issue.