### PR TITLE
Don't show decimal places for percentages

### DIFF
--- a/Fetch/Downloader.swift
+++ b/Fetch/Downloader.swift
@@ -77,7 +77,10 @@ class Downloader {
                     
                     DispatchQueue.main.async {
                         UIApplication.shared.isNetworkActivityIndicatorVisible = true
-                        self.delegate?.percentageChanged(percentage: "\(progress.fractionCompleted * 100)")
+                        let formatter = NumberFormatter()
+                        formatter.numberStyle = .percent
+                        let percentage = formatter.string(from: NSNumber(value: progress.fractionCompleted))
+                        self.delegate?.percentageChanged(percentage: percentage!)
                     }
                     
                 }


### PR DESCRIPTION
Looks like the migration to new Swift version caused the download percentage to show many decimal places.

Before

![messages image 1728982337](https://user-images.githubusercontent.com/44164/33498165-478c9694-d6c8-11e7-8de9-8c534bf360dd.png)

After

![messages image 438645403](https://user-images.githubusercontent.com/44164/33498177-50ae297c-d6c8-11e7-8eff-60211d8209b3.png)

Fixes #11.