### PR TITLE
Show downloaded files in "Files" app and in iTunes

### DIFF
--- a/Fetch/Info.plist
+++ b/Fetch/Info.plist
@@ -74,6 +74,8 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -121,6 +123,8 @@
 		<string>audio</string>
 		<string>remote-notification</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
I'm constantly hitting #22 because days after I build the application something goes strange with provisioning. I've lost access to local downloaded content multiple times while away from computer and it's a little annoying.

As a solution, it would be great if downloaded content in fetch wasn't locked into fetch and the application allowed you to consume the content with other apps, or view downloaded files in the files app.

This pull request enables consuming the downloaded files from the files app:

![img_f1e080ba3ec1-1](https://user-images.githubusercontent.com/44164/37063879-3f36f9ee-219b-11e8-9b72-0667f4b114f5.jpeg)

The side effect, you can extra these files on macOS via iTunes too:

<img width="375" alt="messages image 678071403" src="https://user-images.githubusercontent.com/44164/37064299-ac8d6f4a-219c-11e8-9c0a-eef38c9609b4.png">


This happens by enabling `UIFileSharingEnabled` and `LSSupportsOpeningDocumentsInPlace `:

> #### UIFileSharingEnabled
> In iOS 11 and later, if both this key and the LSSupportsOpeningDocumentsInPlace key are YES, the local file provider grants access to all the documents in the app’s Documents directory. These documents appear in the Files app, and in a Document Browser. Users can open and edit these document in place.

The downside is that it does show the realm store files in Files.app as they are stored in the documents folder. Perhaps it would make sense to move these files outside of Documents or limit the files exported in some way but I am not aware of a trivial way to do this so I left it.